### PR TITLE
Delay spin actions until next animation frame.

### DIFF
--- a/ex8/bower.json
+++ b/ex8/bower.json
@@ -12,6 +12,7 @@
     "purescript-pux-devtool": "^2.0.0",
     "purescript-argonaut": "^0.12.0",
     "purescript-affjax": "^0.13.1",
-    "purescript-debug": "^0.1.5"
+    "purescript-debug": "^0.1.5",
+    "purescript-requestanimationframe": "^1.0.0"
   }
 }

--- a/ex8/src/Layout.purs
+++ b/ex8/src/Layout.purs
@@ -1,16 +1,12 @@
 module App.Layout where
 
 import App.SpinSquare as SpinSquare
-import App.Routes (Route(Home, NotFound))
-import Control.Monad.Aff.AVar (AVAR)
+import App.Routes (Route(NotFound))
 import Control.Timer (TIMER)
-import Data.Int (toNumber)
-import Math (max)
-import Prelude ((#), (+), ($), map, (++), show)
+import DOM (DOM)
+import Prelude ((#), ($), map)
 import Pux (mapEffects, mapState, noEffects, EffModel)
-import Pux.Html (img, Html, div, h1, p, text)
-import Pux.Html.Attributes (width, src)
-import Signal.Time (Time)
+import Pux.Html (Html, div, h1, text)
 
 data Action
   = Child (SpinSquare.Action)
@@ -30,7 +26,7 @@ init =
   , square2: SpinSquare.init
 }
 
-update :: forall e. Action -> State -> EffModel State Action (timer :: TIMER, avar :: AVAR | e)
+update :: forall e. Action -> State -> EffModel State Action (dom :: DOM, timer :: TIMER | e)
 update (PageView route) state = noEffects $ state { route = route }
 update (Child action) state =
   SpinSquare.update action state.square

--- a/ex8/src/Main.purs
+++ b/ex8/src/Main.purs
@@ -2,7 +2,6 @@ module Main where
 
 import App.Layout (Action(PageView), State, view, update)
 import App.Routes (match)
-import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Eff (Eff)
 import Control.Timer (TIMER)
 import DOM (DOM)
@@ -11,7 +10,7 @@ import Pux (App, CoreEffects, renderToDOM)
 import Pux.Router (sampleUrl)
 import Signal ((~>))
 
-type AppEffects = (dom :: DOM, timer :: TIMER, avar :: AVAR)
+type AppEffects = (dom :: DOM, timer :: TIMER)
 
 -- | App configuration
 -- config :: forall e.


### PR DESCRIPTION
You needed the equivalent of Elm's `Effects.tick` function, which is simply a call to `requestAnimationFrame`. You were firing the `Spin` action with no delay in between.
